### PR TITLE
update filters +  add data inreachment from /chains endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",
+    "@lifi/types": "^13.16.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.11.20",
     "@types/react": "^18.2.57",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-icons:
+        specifier: ^5.2.1
+        version: 5.2.1(react@18.2.0)
       react-window:
         specifier: ^1.8.10
         version: 1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -36,6 +39,9 @@ importers:
         specifier: 3.22.4
         version: 3.22.4
     devDependencies:
+      '@lifi/types':
+        specifier: ^13.16.0
+        version: 13.16.0
       '@playwright/test':
         specifier: ^1.44.1
         version: 1.44.1
@@ -152,6 +158,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@lifi/types@13.16.0':
+    resolution: {integrity: sha512-K9k3sLJ4Xq26KTdkWk7Z0+UopopSw7EHlqmBJ3NS9QTbJS85ih9WiT+dqhKeANBYOQ9oitZyScJf9YKjTnzK/Q==}
 
   '@next/env@14.2.2':
     resolution: {integrity: sha512-sk72qRfM1Q90XZWYRoJKu/UWlTgihrASiYw/scb15u+tyzcze3bOuJ/UV6TBOQEeUaxOkRqGeuGUdiiuxc5oqw==}
@@ -1465,6 +1474,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
+  react-icons@5.2.1:
+    resolution: {integrity: sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1843,6 +1857,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@lifi/types@13.16.0': {}
 
   '@next/env@14.2.2': {}
 
@@ -3283,6 +3299,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  react-icons@5.2.1(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   react-is@16.13.1: {}
 

--- a/src/components/token-list/TokenList.tsx
+++ b/src/components/token-list/TokenList.tsx
@@ -6,6 +6,16 @@ import {
 } from "react-window";
 import { TToken, TTokenFilter } from "~/lib/api";
 import TokenRow from "~/components/token-list/Row"
+import { ChainId } from "@lifi/types"
+
+
+const chainOptions = Object.entries(ChainId)
+  .filter(([key, value]) => typeof value === 'number')
+  .map(([key, value]) => (
+    <option key={value as number} value={value as number}>
+      {key}
+    </option>
+  ));
 
 const TokenList = ({ data }: { data: TToken[] }) => {
   const [filter, setFilter] = useState<TTokenFilter>({
@@ -24,7 +34,7 @@ const TokenList = ({ data }: { data: TToken[] }) => {
     const filteredTokens: TToken[] = data.filter( token => {
       return (
         (!filter.chainId || token.chainId === filter.chainId) &&
-        (!filter.chainType || token.coinKey === filter.chainType)
+        (!filter.chainType || token.chainType === filter.chainType)
       );
       });
   
@@ -55,9 +65,7 @@ const TokenList = ({ data }: { data: TToken[] }) => {
           className="m-2 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:inline-block sm:w-auto sm:text-sm"
         >
           <option value="0">Select Chains</option>
-          <option value="1">Ethereum</option>
-          <option value="100">MakerDAO</option>
-          <option value="137">Polygon</option> 
+          {chainOptions}
           <option></option>     
         </select>
         <select

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,10 @@
 import * as z from "zod";
 import { EVMAddress } from "~/domains/evm";
+import {ExtendedChain} from "@lifi/types";
 
 const API_URL = "https://li.quest/v1/tokens";
+const CHAIN_API_URL = 'https://li.quest/v1/chains';
+
 
 // @todo find this model in LIFI codebase
 export const TokenSchema = z.object({
@@ -13,6 +16,7 @@ export const TokenSchema = z.object({
   name: z.string(),
   priceUSD: z.string(),
   symbol: z.string(),
+  chainType: z.string().optional()
 });
 
 export type TToken = z.infer<typeof TokenSchema>;
@@ -24,13 +28,38 @@ export const TokenFilterSchema = z.object({
 
 export type TTokenFilter = z.infer<typeof TokenFilterSchema>;
 
-export const fetchTokens = async () => {
-  const res = await fetch(API_URL);
+const fetchChainData = async (): Promise<{ [key: number]: string }> => {
+  const res = await fetch(`${CHAIN_API_URL}?chainTypes=EVM%2CSVM`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch chain data: ${res.statusText}`);
+  }
+  const data = await res.json();
+  const chainData: ExtendedChain[] = data.chains;
+
+  const chainTypeMapping: { [key: number]: string } = {};
+  chainData.forEach((chain) => {
+    chainTypeMapping[chain.id] = chain.chainType;
+  });
+
+  return chainTypeMapping;
+};
+
+export const fetchTokens = async (): Promise<TToken[]> => {
+  const chainTypeMapping = await fetchChainData();
+
+  const res = await fetch(`${API_URL}?chainTypes=EVM%2CSVM`);  // By default API returns only EVM tokens
   if (!res.ok) {
     throw new Error(`Failed to fetch tokens: ${res.statusText}`);
   }
   const data = await res.json();
   const tokenData = data.tokens;
-  const tokensArray = Object.values(tokenData).flat().map((x) => TokenSchema.parse(x)) as TToken[];
+
+  const tokensArray: TToken[] = Object.entries(tokenData).flatMap(([chainId, tokens]: [string, any]) => {
+    return tokens.map((token: any) => ({
+      ...token,
+      chainType: chainTypeMapping[parseInt(chainId, 10)] || 'Unknown',
+    }));
+  });
+
   return tokensArray;
 };


### PR DESCRIPTION
Logic update to dynamically fetch the chain types and filter tokens accordingly based on the chainType mapping from the API response and  chainId imported from "@lifi/types" package
Improvements:
1. Fetch chain data and create a chainType mapping.
2. Update the fetchTokens function to include the chainType.
3. Filter the tokens by the specified chainId utilizing "@lifi/types" package
4. Filter the tokens by the specified chainTypes utilizing "@lifi/types" package
